### PR TITLE
Fix deprecation warning for ActiveRecord::Base.set_table_name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,23 @@
 PATH
   remote: .
   specs:
-    has_draft (1.0.2)
+    has_draft (1.1.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.12)
-      activesupport (= 3.0.12)
+    activemodel (3.0.20)
+      activesupport (= 3.0.20)
       builder (~> 2.1.2)
       i18n (~> 0.5.0)
-    activerecord (3.0.12)
-      activemodel (= 3.0.12)
-      activesupport (= 3.0.12)
+    activerecord (3.0.20)
+      activemodel (= 3.0.20)
+      activesupport (= 3.0.20)
       arel (~> 2.0.10)
       tzinfo (~> 0.3.23)
-    activesupport (3.0.12)
+    activesupport (3.0.20)
     appraisal (0.4.1)
       bundler
       rake
@@ -38,7 +38,7 @@ GEM
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.5.0)
     sqlite3 (1.3.5)
-    tzinfo (0.3.32)
+    tzinfo (0.3.35)
 
 PLATFORMS
   ruby

--- a/lib/has_draft.rb
+++ b/lib/has_draft.rb
@@ -29,7 +29,7 @@ module HasDraft
       
       draft_class.cattr_accessor :original_class
       draft_class.original_class = self
-      draft_class.set_table_name(draft_table_name)
+      draft_class.table_name = draft_table_name
       
       # Draft Parent Association
       draft_class.belongs_to self.to_s.demodulize.underscore.to_sym, :class_name  => "::#{self.to_s}", :foreign_key => draft_foreign_key


### PR DESCRIPTION
Gets rid of warnings like

DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead.
