### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/has_draft.gemspec
+++ b/has_draft.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version     = HasDraft::VERSION
   s.author      = "Ben Hughes"
   s.email       = "ben@railsgarden.com"
-  s.homepage    = "http://github.com/rubiety/has_draft"
+  s.homepage    = "https://github.com/rubiety/has_draft"
   s.summary     = "Attached draft model to your ActiveRecord models."
   s.description = "Allows for your ActiveRecord models to have drafts which are stored in a separate duplicate table."
   s.license     = "MIT"
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.files        = Dir["{lib,spec}/**/*", "[A-Z]*", "init.rb"]
   s.require_path = "lib"
 
-  s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"
 
   s.add_dependency("activesupport", [">= 3.0.0"])


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.

(Also: Point to https URI to homepage.)